### PR TITLE
Add separate timeout flag for writer

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -64,11 +64,17 @@ var (
 		Usage:  "If set to true, will fetch the list of quorums registered in the contract and update all of them",
 		EnvVar: envVarPrefix + "FETCH_QUORUMS_DYNAMICALLY",
 	}
-	RpcTimeoutDurationFlag = cli.DurationFlag{
-		Name:   "rpc-timeout-duration",
-		Usage:  "Timeout duration for rpc calls in `SECONDS`",
+	ReaderTimeoutDurationFlag = cli.DurationFlag{
+		Name:   "reader-timeout-duration",
+		Usage:  "Timeout duration for rpc calls to read from chain in `SECONDS`",
 		Value:  5 * time.Second,
-		EnvVar: envVarPrefix + "RPC_TIMEOUT_DURATION",
+		EnvVar: envVarPrefix + "READER_TIMEOUT_DURATION",
+	}
+	WriterTimeoutDurationFlag = cli.DurationFlag{
+		Name:   "writer-timeout-duration",
+		Usage:  "Timeout duration for transactions to be confirmed in `SECONDS`",
+		Value:  90 * time.Second,
+		EnvVar: envVarPrefix + "WRITER_TIMEOUT_DURATION",
 	}
 	retrySyncNTimes = cli.IntFlag{
 		Name:   "retry-sync-n-times",
@@ -91,7 +97,8 @@ var OptionalFlags = []cli.Flag{
 	OperatorListFlag,
 	QuorumListFlag,
 	FetchQuorumDynamicallyFlag,
-	RpcTimeoutDurationFlag,
+	ReaderTimeoutDurationFlag,
+	WriterTimeoutDurationFlag,
 	retrySyncNTimes,
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -259,6 +259,7 @@ func NewTestAvsSync(anvilHttpEndpoint string, contractAddresses ContractAddresse
 		false,
 		1, // 1 retry
 		5*time.Second,
+		5*time.Second,
 	)
 	return avsSync
 }

--- a/main.go
+++ b/main.go
@@ -108,7 +108,8 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		quorums,
 		cliCtx.Bool(FetchQuorumDynamicallyFlag.Name),
 		cliCtx.Int(retrySyncNTimes.Name),
-		cliCtx.Duration(RpcTimeoutDurationFlag.Name),
+		cliCtx.Duration(ReaderTimeoutDurationFlag.Name),
+		cliCtx.Duration(WriterTimeoutDurationFlag.Name),
 	)
 	avsSync.Start()
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Previously, it was using `rpcTimeoutDuration` as a timeout for both read & write onchain. However, there should be two distinct timeouts for read & write operations.
### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

This PR distinguishes the two timeouts (read vs. write), and adds another flag to represent the write timeout as writing (sending transactions) onchain should take a lot longer time.

Ideally, the transaction manager in eigensdk supports retries and gas fee bumps, but this can be a temporary solution till that's supported. 
