### PR TITLE
Enable a single update

### DIFF
--- a/avssync.go
+++ b/avssync.go
@@ -59,10 +59,6 @@ func (a *AvsSync) Start() {
 	a.logger.Infof("Starting avs sync with sleepBeforeFirstSyncDuration=%s, syncInterval=%s, operators=%v, quorums=%v, fetchQuorumsDynamically=%v, readerTimeoutDuration=%s, writerTimeoutDuration=%s",
 		a.sleepBeforeFirstSyncDuration, a.syncInterval, a.operators, a.quorums, a.fetchQuorumsDynamically, a.readerTimeoutDuration, a.writerTimeoutDuration)
 
-	// run something every syncInterval
-	ticker := time.NewTicker(a.syncInterval)
-	defer ticker.Stop()
-
 	// ticker doesn't tick immediately, so we send a first updateStakes here
 	// see https://github.com/golang/go/issues/17601
 	// we first sleep some amount of time before the first sync, which allows the syncs to happen at some preferred time
@@ -72,6 +68,15 @@ func (a *AvsSync) Start() {
 	if err != nil {
 		a.logger.Error("Error updating stakes", err)
 	}
+
+	if a.syncInterval == 0 {
+		a.logger.Infof("Sync interval is 0, running updateStakes once and exiting")
+		return // only run once
+	}
+
+	// update stakes every syncInterval
+	ticker := time.NewTicker(a.syncInterval)
+	defer ticker.Stop()
 
 	for range ticker.C {
 		err := a.updateStakes()

--- a/flags.go
+++ b/flags.go
@@ -37,7 +37,7 @@ var (
 	SyncIntervalFlag = cli.DurationFlag{
 		Name:     "sync-interval",
 		Required: true,
-		Usage:    "call updateStakes function at every `TIME` interval",
+		Usage:    "Interval at which to sync with the chain (e.g. 24h). If set to 0, will only sync once and then exit.",
 		Value:    24 * time.Hour,
 		EnvVar:   envVarPrefix + "SYNC_INTERVAL",
 	}

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		cliCtx.Duration(ReaderTimeoutDurationFlag.Name),
 		cliCtx.Duration(WriterTimeoutDurationFlag.Name),
 	)
-	avsSync.Start()
 
+	avsSync.Start()
 	return nil
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Currently, it's designed to run continuously and make updates every given interval.
However, it would be nice to have it run once and exit, so that it can be set up as a cron job. 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This PR enables the program to make the update onchain and exit if `SYNC_INTERVAL` is set to 0. 
