### PR TITLE
Make `avssync` package

### DIFF
--- a/avssync/avssync.go
+++ b/avssync/avssync.go
@@ -61,7 +61,7 @@ func NewAvsSync(
 	}
 }
 
-func (a *AvsSync) Start() {
+func (a *AvsSync) Start(ctx context.Context) {
 	// TODO: should prob put all of these in a config struct, to make sure we don't forget to print any of them
 	//       when we add new ones.
 	a.logger.Info("Avssync config",
@@ -97,9 +97,15 @@ func (a *AvsSync) Start() {
 	ticker := time.NewTicker(a.syncInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		a.updateStakes()
-		a.logger.Infof("Sleeping for %s", a.syncInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			a.logger.Info("Context done, exiting")
+			return
+		case <-ticker.C:
+			a.updateStakes()
+			a.logger.Infof("Sleeping for %s", a.syncInterval)
+		}
 	}
 }
 

--- a/avssync/avssync.go
+++ b/avssync/avssync.go
@@ -1,4 +1,4 @@
-package main
+package avssync
 
 import (
 	"context"
@@ -16,16 +16,16 @@ import (
 )
 
 type AvsSync struct {
-	logger    sdklogging.Logger
-	avsReader avsregistry.AvsRegistryReader
-	avsWriter avsregistry.AvsRegistryWriter
+	AvsReader       avsregistry.AvsRegistryReader
+	AvsWriter       avsregistry.AvsRegistryWriter
+	RetrySyncNTimes int
 
+	logger                       sdklogging.Logger
 	sleepBeforeFirstSyncDuration time.Duration
 	syncInterval                 time.Duration
 	operators                    []common.Address // empty means we update all operators
 	quorums                      []byte
 	fetchQuorumsDynamically      bool
-	retrySyncNTimes              int
 
 	readerTimeoutDuration time.Duration
 	writerTimeoutDuration time.Duration
@@ -46,15 +46,15 @@ func NewAvsSync(
 	prometheusServerAddr string,
 ) *AvsSync {
 	return &AvsSync{
+		AvsReader:                    avsReader,
+		AvsWriter:                    avsWriter,
+		RetrySyncNTimes:              retrySyncNTimes,
 		logger:                       logger,
-		avsReader:                    avsReader,
-		avsWriter:                    avsWriter,
 		sleepBeforeFirstSyncDuration: sleepBeforeFirstSyncDuration,
 		syncInterval:                 syncInterval,
 		operators:                    operators,
 		quorums:                      quorums,
 		fetchQuorumsDynamically:      fetchQuorumsDynamically,
-		retrySyncNTimes:              retrySyncNTimes,
 		readerTimeoutDuration:        readerTimeoutDuration,
 		writerTimeoutDuration:        writerTimeoutDuration,
 		prometheusServerAddr:         prometheusServerAddr,
@@ -112,7 +112,7 @@ func (a *AvsSync) updateStakes() {
 		// we update one quorum at a time, just to make sure we don't run into any gas limit issues
 		// in case there are a lot of operators in a given quorum
 		for _, quorum := range a.quorums {
-			a.tryNTimesUpdateStakesOfEntireOperatorSetForQuorum(quorum, a.retrySyncNTimes)
+			a.tryNTimesUpdateStakesOfEntireOperatorSetForQuorum(quorum, a.RetrySyncNTimes)
 		}
 		a.logger.Info("Completed stake update. Check logs to make sure every quorum update succeeded successfully.")
 	} else {
@@ -120,7 +120,7 @@ func (a *AvsSync) updateStakes() {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), a.writerTimeoutDuration)
 		defer cancel()
 		// this one we update all quorums at once, since we're only updating a subset of operators (which should be a small number)
-		receipt, err := a.avsWriter.UpdateStakesOfOperatorSubsetForAllQuorums(timeoutCtx, a.operators)
+		receipt, err := a.AvsWriter.UpdateStakesOfOperatorSubsetForAllQuorums(timeoutCtx, a.operators)
 		if err != nil {
 			// no quorum label means we are updating all quorums
 			updateStakeAttempt.With(prometheus.Labels{"status": string(UpdateStakeStatusError), "quorum": ""}).Inc()
@@ -143,7 +143,7 @@ func (a *AvsSync) maybeUpdateQuorumSet() {
 	a.logger.Info("Fetching quorum set dynamically")
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), a.readerTimeoutDuration)
 	defer cancel()
-	quorumCount, err := a.avsReader.GetQuorumCount(&bind.CallOpts{Context: timeoutCtx})
+	quorumCount, err := a.AvsReader.GetQuorumCount(&bind.CallOpts{Context: timeoutCtx})
 	if err != nil {
 		a.logger.Error("Error fetching quorum set dynamically", err)
 		return
@@ -165,7 +165,7 @@ func (a *AvsSync) tryNTimesUpdateStakesOfEntireOperatorSetForQuorum(quorum byte,
 		defer cancel()
 		// we need to refetch the operator set because one reason for update stakes failing is that the operator set has changed
 		// in between us fetching it and trying to update it (the contract makes sure the entire operator set is updated and reverts if not)
-		operatorAddrsPerQuorum, err := a.avsReader.GetOperatorAddrsInQuorumsAtCurrentBlock(&bind.CallOpts{Context: timeoutCtx}, types.QuorumNums{types.QuorumNum(quorum)})
+		operatorAddrsPerQuorum, err := a.AvsReader.GetOperatorAddrsInQuorumsAtCurrentBlock(&bind.CallOpts{Context: timeoutCtx}, types.QuorumNums{types.QuorumNum(quorum)})
 		if err != nil {
 			a.logger.Warn("Error fetching operator addresses in quorums", "err", err, "quorum", quorum, "retryNTimes", retryNTimes, "try", i+1)
 			continue
@@ -179,7 +179,7 @@ func (a *AvsSync) tryNTimesUpdateStakesOfEntireOperatorSetForQuorum(quorum byte,
 		a.logger.Infof("Updating stakes of operators in quorum %d: %v", int(quorum), operators)
 		timeoutCtx, cancel = context.WithTimeout(context.Background(), a.writerTimeoutDuration)
 		defer cancel()
-		receipt, err := a.avsWriter.UpdateStakesOfEntireOperatorSetForQuorums(timeoutCtx, [][]common.Address{operators}, types.QuorumNums{types.QuorumNum(quorum)})
+		receipt, err := a.AvsWriter.UpdateStakesOfEntireOperatorSetForQuorums(timeoutCtx, [][]common.Address{operators}, types.QuorumNums{types.QuorumNum(quorum)})
 		if err != nil {
 			a.logger.Warn("Error updating stakes of entire operator set for quorum", "err", err, "quorum", int(quorum), "retryNTimes", retryNTimes, "try", i+1)
 			continue

--- a/avssync/metrics.go
+++ b/avssync/metrics.go
@@ -1,4 +1,4 @@
-package main
+package avssync
 
 import (
 	"net/http"
@@ -40,5 +40,7 @@ func StartMetricsServer(metricsAddr string) {
 	registry.MustRegister(updateStakeAttempt, txRevertedTotal, operatorsUpdated)
 	http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	// not sure if we need to handle this error, since if metric server errors, then we will get alerts from grafana
-	go http.ListenAndServe(metricsAddr, nil)
+	go func() {
+		_ = http.ListenAndServe(metricsAddr, nil)
+	}()
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -65,7 +65,7 @@ func TestIntegrationUpdateSingleOperatorPath(t *testing.T) {
 	}
 	operatorAddr := crypto.PubkeyToAddress(operatorEcdsaPrivKey.PublicKey)
 	operatorBlsPrivKey := "0x1"
-	c := NewAvsSyncComponents(t, anvilHttpEndpoint, contractAddresses, []common.Address{operatorAddr}, 30*time.Second)
+	c := NewAvsSyncComponents(t, anvilHttpEndpoint, contractAddresses, []common.Address{operatorAddr}, 0)
 	avsSync := c.avsSync
 
 	// first register operator into avs. at this point, the operator will have whatever stake it had registered in eigenlayer in the avs
@@ -122,7 +122,7 @@ func TestIntegrationFullOperatorSet(t *testing.T) {
 	}
 	operatorAddr := crypto.PubkeyToAddress(operatorEcdsaPrivKey.PublicKey)
 	operatorBlsPrivKey := "0x1"
-	c := NewAvsSyncComponents(t, anvilHttpEndpoint, contractAddresses, []common.Address{}, 30*time.Second)
+	c := NewAvsSyncComponents(t, anvilHttpEndpoint, contractAddresses, []common.Address{}, 0)
 	avsSync := c.avsSync
 
 	// first register operator into avs. at this point, the operator will have whatever stake it had registered in eigenlayer in the avs
@@ -182,7 +182,7 @@ func TestIntegrationFullOperatorSetWithRetry(t *testing.T) {
 	operatorBlsPrivKey := "0x1"
 	// we create avs sync and replace its avsWriter with a mock that will fail the first 2 times we call UpdateStakesOfEntireOperatorSetForQuorums
 	// and succeed on the third time
-	c := NewAvsSyncComponents(t, anvilHttpEndpoint, contractAddresses, []common.Address{}, 30*time.Second)
+	c := NewAvsSyncComponents(t, anvilHttpEndpoint, contractAddresses, []common.Address{}, 0)
 	avsSync := c.avsSync
 
 	// first register operator into avs. at this point, the operator will have whatever stake it had registered in eigenlayer in the avs
@@ -198,8 +198,8 @@ func TestIntegrationFullOperatorSetWithRetry(t *testing.T) {
 
 	// run avsSync
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	go avsSync.Start(ctx)
 	defer cancel()
+	go avsSync.Start(ctx)
 }
 
 func TestSingleRun(t *testing.T) {
@@ -329,8 +329,8 @@ func NewAvsSyncComponents(t *testing.T, anvilHttpEndpoint string, contractAddres
 		[]byte{0},
 		false,
 		1, // 1 retry
-		5*time.Second,
-		5*time.Second,
+		time.Second,
+		time.Second,
 		"", // no metrics server (otherwise parallel tests all try to start server at same endpoint and error out)
 	)
 	return &AvsSyncComponents{

--- a/integration_test.go
+++ b/integration_test.go
@@ -349,7 +349,7 @@ func startAnvilTestContainer() testcontainers.Container {
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image: "ghcr.io/foundry-rs/foundry:latest",
+		Image: "ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a",
 		Mounts: testcontainers.ContainerMounts{
 			testcontainers.ContainerMount{
 				Source: testcontainers.GenericBindMountSource{
@@ -385,19 +385,15 @@ func advanceChainByNBlocks(n int, anvilC testcontainers.Container) {
 	}
 	rpcUrl := "http://" + anvilEndpoint
 	// this is just the first anvil address, which is funded so can send ether
-	address := "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-	privateKey := "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-	for i := 0; i < n; i++ {
-		// we just send a transaction to ourselves to advance the chain
-		cmd := exec.Command("bash", "-c",
-			fmt.Sprintf(
-				`cast send %s --value 0.01ether --private-key %s --rpc-url %s`,
-				address, privateKey, rpcUrl),
-		)
-		err = cmd.Run()
-		if err != nil {
-			panic(err)
-		}
+	// we just send a transaction to ourselves to advance the chain
+	cmd := exec.Command("bash", "-c",
+		fmt.Sprintf(
+			`cast rpc anvil_mine %d --rpc-url %s`,
+			n, rpcUrl),
+	)
+	err = cmd.Run()
+	if err != nil {
+		panic(err)
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -83,7 +83,7 @@ func TestIntegrationUpdateSingleOperatorPath(t *testing.T) {
 	depositErc20IntoStrategyForOperator(c.wallet, anvilHttpEndpoint, contractAddresses.DelegationManager, contractAddresses.Erc20MockStrategy, operatorEcdsaPrivKeyHex, operatorAddr.Hex(), depositAmount)
 
 	// run avsSync
-	go avsSync.Start()
+	go avsSync.Start(context.Background())
 	time.Sleep(5 * time.Second)
 
 	// get stake of operator after sync
@@ -141,7 +141,7 @@ func TestIntegrationFullOperatorSet(t *testing.T) {
 	depositErc20IntoStrategyForOperator(c.wallet, anvilHttpEndpoint, contractAddresses.DelegationManager, contractAddresses.Erc20MockStrategy, operatorEcdsaPrivKeyHex, operatorAddr.Hex(), depositAmount)
 
 	// run avsSync
-	go avsSync.Start()
+	go avsSync.Start(context.Background())
 	time.Sleep(5 * time.Second)
 
 	// get stake of operator after sync
@@ -197,9 +197,9 @@ func TestIntegrationFullOperatorSetWithRetry(t *testing.T) {
 	avsSync.RetrySyncNTimes = 3
 
 	// run avsSync
-	go avsSync.Start()
-	time.Sleep(5 * time.Second)
-
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	go avsSync.Start(ctx)
+	defer cancel()
 }
 
 func TestSingleRun(t *testing.T) {
@@ -239,7 +239,7 @@ func TestSingleRun(t *testing.T) {
 	depositAmount := big.NewInt(100)
 	depositErc20IntoStrategyForOperator(c.wallet, anvilHttpEndpoint, contractAddresses.DelegationManager, contractAddresses.Erc20MockStrategy, operatorEcdsaPrivKeyHex, operatorAddr.Hex(), depositAmount)
 
-	avsSync.Start()
+	avsSync.Start(context.Background())
 
 	// get stake of operator after sync
 	operatorsPerQuorumAfterSync, err := avsSync.AvsReader.GetOperatorsStakeInQuorumsAtCurrentBlock(&bind.CallOpts{}, []types.QuorumNum{0})

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Layr-Labs/avs-sync/avssync"
 	"github.com/Layr-Labs/eigensdk-go/aws/secretmanager"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
@@ -207,7 +208,7 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		sleepBeforeFirstSyncDuration = firstSyncTime.Sub(now)
 	}
 	logger.Infof("Sleeping for %v before first sync, so that it happens at %v", sleepBeforeFirstSyncDuration, time.Now().Add(sleepBeforeFirstSyncDuration))
-	avsSync := NewAvsSync(
+	avsSync := avssync.NewAvsSync(
 		logger,
 		avsReader,
 		avsWriter,

--- a/main.go
+++ b/main.go
@@ -223,6 +223,6 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		cliCtx.String(MetricsAddrFlag.Name),
 	)
 
-	avsSync.Start()
+	avsSync.Start(context.Background())
 	return nil
 }


### PR DESCRIPTION
Instead of defining `AvsSync` at the top level package `main`, make it its own package so it can be imported as a library.