### PR TITLE
Pass in metrics server to avssync

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -273,7 +273,7 @@ func NewAvsSyncComponents(t *testing.T, anvilHttpEndpoint string, contractAddres
 		1, // 1 retry
 		time.Second,
 		time.Second,
-		"", // no metrics server (otherwise parallel tests all try to start server at same endpoint and error out)
+		nil, // no metrics server (otherwise parallel tests all try to start server at same endpoint and error out)
 	)
 	return &AvsSyncComponents{
 		avsSync:   avsSync,

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		sleepBeforeFirstSyncDuration = firstSyncTime.Sub(now)
 	}
 	logger.Infof("Sleeping for %v before first sync, so that it happens at %v", sleepBeforeFirstSyncDuration, time.Now().Add(sleepBeforeFirstSyncDuration))
+	metrics := avssync.NewMetrics(cliCtx.String(MetricsAddrFlag.Name), logger)
 	avsSync := avssync.NewAvsSync(
 		logger,
 		avsReader,
@@ -220,7 +221,7 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		cliCtx.Int(retrySyncNTimes.Name),
 		readerTimeout,
 		writerTimeout,
-		cliCtx.String(MetricsAddrFlag.Name),
+		metrics,
 	)
 
 	avsSync.Start(context.Background())


### PR DESCRIPTION
Instead of creating a metrics server inside avssync, this change makes avssync constructor take the metrics server itself so that it can be passed in from the caller.