### PR TITLE
Refactor metrics on AVS sync

### DIFF
--- a/avssync/avssync.go
+++ b/avssync/avssync.go
@@ -47,7 +47,7 @@ func NewAvsSync(
 	prometheusServerAddr string,
 	prometheusRegistry *prometheus.Registry,
 ) *AvsSync {
-	metrics := NewMetrics(prometheusRegistry, prometheusServerAddr)
+	metrics := NewMetrics(prometheusRegistry)
 
 	return &AvsSync{
 		AvsReader:                    avsReader,
@@ -135,7 +135,7 @@ func (a *AvsSync) updateStakes() {
 		if err != nil {
 			// no quorum label means we are updating all quorums
 			for _, quorum := range a.quorums {
-				a.Metrics.UpdateStakeAttempt(UpdateStakeStatusError, strconv.Itoa(int(quorum)))
+				a.Metrics.UpdateStakeAttemptInc(UpdateStakeStatusError, strconv.Itoa(int(quorum)))
 			}
 			a.logger.Error("Error updating stakes of operator subset for all quorums", err)
 			return
@@ -203,14 +203,14 @@ func (a *AvsSync) tryNTimesUpdateStakesOfEntireOperatorSetForQuorum(quorum byte,
 		}
 
 		// Update metrics on success
-		a.Metrics.UpdateStakeAttempt(UpdateStakeStatusSucceed, strconv.Itoa(int(quorum)))
+		a.Metrics.UpdateStakeAttemptInc(UpdateStakeStatusSucceed, strconv.Itoa(int(quorum)))
 		a.Metrics.OperatorsUpdatedSet(strconv.Itoa(int(quorum)), len(operators))
 
 		return
 	}
 
 	// Update metrics on failure
-	a.Metrics.UpdateStakeAttempt(UpdateStakeStatusError, strconv.Itoa(int(quorum)))
+	a.Metrics.UpdateStakeAttemptInc(UpdateStakeStatusError, strconv.Itoa(int(quorum)))
 	a.logger.Error("Giving up after retrying", "retryNTimes", retryNTimes)
 }
 

--- a/avssync/avssync.go
+++ b/avssync/avssync.go
@@ -45,9 +45,9 @@ func NewAvsSync(
 	quorums []byte, fetchQuorumsDynamically bool, retrySyncNTimes int,
 	readerTimeoutDuration time.Duration, writerTimeoutDuration time.Duration,
 	prometheusServerAddr string,
+	prometheusRegistry *prometheus.Registry,
 ) *AvsSync {
-	promReg := prometheus.NewRegistry()
-	metrics := NewMetrics(promReg)
+	metrics := NewMetrics(prometheusRegistry, prometheusServerAddr)
 
 	return &AvsSync{
 		AvsReader:                    avsReader,

--- a/avssync/metrics.go
+++ b/avssync/metrics.go
@@ -18,28 +18,28 @@ const (
 )
 
 type Metrics struct {
-	UpdateStakeAttempts *prometheus.CounterVec
-	TxRevertedTotal     prometheus.Counter
-	OperatorsUpdated    *prometheus.GaugeVec
+	updateStakeAttempts *prometheus.CounterVec
+	txRevertedTotal     prometheus.Counter
+	operatorsUpdated    *prometheus.GaugeVec
 
 	registry *prometheus.Registry
 }
 
 func NewMetrics(reg *prometheus.Registry) *Metrics {
 	metrics := &Metrics{
-		UpdateStakeAttempts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		updateStakeAttempts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Name:      "update_stake_attempt",
 			Help:      "Result from an update stake attempt. Either succeed or error (either tx was mined but reverted, or failed to get processed by chain).",
 		}, []string{"status", "quorum"}),
 
-		TxRevertedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		txRevertedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Name:      "tx_reverted_total",
 			Help:      "The total number of transactions that made it onchain but reverted (most likely because out of gas)",
 		}),
 
-		OperatorsUpdated: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		operatorsUpdated: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Name:      "operators_updated",
 			Help:      "The total number of operators updated (during the last quorum sync)",
@@ -51,17 +51,16 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 	return metrics
 }
 
-func (g *Metrics) UpdateStakeAttempt(status UpdateStakeStatus, quorum string) {
-	g.UpdateStakeAttempts.WithLabelValues(string(status), quorum).Inc()
+func (g *Metrics) UpdateStakeAttemptInc(status UpdateStakeStatus, quorum string) {
+	g.updateStakeAttempts.WithLabelValues(string(status), quorum).Inc()
 }
 
 func (g *Metrics) TxRevertedTotalInc() {
-	g.TxRevertedTotal.Inc()
+	g.txRevertedTotal.Inc()
 }
 
-// operatorsUpdated.With(prometheus.Labels{"quorum": strconv.Itoa(int(quorum))}).Set(float64(len(operators)))
 func (g *Metrics) OperatorsUpdatedSet(quorum string, operators int) {
-	g.OperatorsUpdated.WithLabelValues(quorum).Set(float64(operators))
+	g.operatorsUpdated.WithLabelValues(quorum).Set(float64(operators))
 }
 
 func (g *Metrics) Start(metricsAddr string) {

--- a/avssync/metrics.go
+++ b/avssync/metrics.go
@@ -17,28 +17,53 @@ const (
 	UpdateStakeStatusSucceed UpdateStakeStatus = "succeed"
 )
 
-var (
-	updateStakeAttempt = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Name:      "update_stake_attempt",
-		Help:      "Result from an update stake attempt. Either succeed or error (either tx was mined but reverted, or failed to get processed by chain).",
-	}, []string{"status", "quorum"})
-	txRevertedTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Name:      "tx_reverted_total",
-		Help:      "The total number of transactions that made it onchain but reverted (most likely because out of gas)",
-	})
-	operatorsUpdated = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: metricsNamespace,
-		Name:      "operators_updated",
-		Help:      "The total number of operators updated (during the last quorum sync)",
-	}, []string{"quorum"})
-)
+type Metrics struct {
+	UpdateStakeAttempts *prometheus.CounterVec
+	TxRevertedTotal     prometheus.Counter
+	OperatorsUpdated    *prometheus.GaugeVec
 
-func StartMetricsServer(metricsAddr string) {
-	registry := prometheus.NewRegistry()
-	registry.MustRegister(updateStakeAttempt, txRevertedTotal, operatorsUpdated)
-	http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	registry *prometheus.Registry
+}
+
+func NewMetrics(reg *prometheus.Registry) *Metrics {
+	metrics := &Metrics{
+		UpdateStakeAttempts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "update_stake_attempt",
+			Help:      "Result from an update stake attempt. Either succeed or error (either tx was mined but reverted, or failed to get processed by chain).",
+		}, []string{"status", "quorum"}),
+
+		TxRevertedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "tx_reverted_total",
+			Help:      "The total number of transactions that made it onchain but reverted (most likely because out of gas)",
+		}),
+
+		OperatorsUpdated: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "operators_updated",
+			Help:      "The total number of operators updated (during the last quorum sync)",
+		}, []string{"quorum"}),
+	}
+
+	return metrics
+}
+
+func (g *Metrics) UpdateStakeAttempt(status UpdateStakeStatus, quorum string) {
+	g.UpdateStakeAttempts.WithLabelValues(string(status), quorum).Inc()
+}
+
+func (g *Metrics) TxRevertedTotalInc() {
+	g.TxRevertedTotal.Inc()
+}
+
+// operatorsUpdated.With(prometheus.Labels{"quorum": strconv.Itoa(int(quorum))}).Set(float64(len(operators)))
+func (g *Metrics) OperatorsUpdatedSet(quorum string, operators int) {
+	g.OperatorsUpdated.WithLabelValues(quorum).Set(float64(operators))
+}
+
+func (g *Metrics) Start(metricsAddr string) {
+	http.Handle("/metrics", promhttp.HandlerFor(g.registry, promhttp.HandlerOpts{}))
 	// not sure if we need to handle this error, since if metric server errors, then we will get alerts from grafana
 	go func() {
 		_ = http.ListenAndServe(metricsAddr, nil)

--- a/avssync/metrics.go
+++ b/avssync/metrics.go
@@ -44,6 +44,8 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Name:      "operators_updated",
 			Help:      "The total number of operators updated (during the last quorum sync)",
 		}, []string{"quorum"}),
+
+		registry: reg,
 	}
 
 	return metrics

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.uber.org/mock/gomock"
@@ -274,6 +275,7 @@ func NewAvsSyncComponents(t *testing.T, anvilHttpEndpoint string, contractAddres
 		time.Second,
 		time.Second,
 		"", // no metrics server (otherwise parallel tests all try to start server at same endpoint and error out)
+		prometheus.NewRegistry(),
 	)
 	return &AvsSyncComponents{
 		avsSync:   avsSync,

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/signerv2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli"
 )
 
@@ -208,6 +209,10 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		sleepBeforeFirstSyncDuration = firstSyncTime.Sub(now)
 	}
 	logger.Infof("Sleeping for %v before first sync, so that it happens at %v", sleepBeforeFirstSyncDuration, time.Now().Add(sleepBeforeFirstSyncDuration))
+
+	// Create new prometheus registry
+	reg := prometheus.NewRegistry()
+
 	avsSync := avssync.NewAvsSync(
 		logger,
 		avsReader,
@@ -221,6 +226,7 @@ func avsSyncMain(cliCtx *cli.Context) error {
 		readerTimeout,
 		writerTimeout,
 		cliCtx.String(MetricsAddrFlag.Name),
+		reg,
 	)
 
 	avsSync.Start(context.Background())


### PR DESCRIPTION
Adds avs sync metrics to a Metrics struct and expose updates to such metrics through the metrics library.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->