### PR TITLE
typo fix CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,7 +69,7 @@ Read carefully our Contributing Guidelines to know how to contribute properly in
 project. Members and maintainers must adhere to some rules regarding to pull requests
 reviews and creation of issues and pull requests:
 
-* During code reviews do not comment on coding standards and styles -focus on algorithmical,
+* During code reviews do not comment on coding standards and styles -focus on algorithmically,
 structural or naming issues-, help to solve problem.
 * When creating an issue or a pull request, follow the templates provided by the repository and
 fill in the indicated items correctly. If you do not want to use a template, open a blank issue/PR


### PR DESCRIPTION

Fixed a typo in `CODE_OF_CONDUCT.md`, changing **"algorithmical"** to **"algorithmically"** to ensure proper phrasing and grammar.
