### PR TITLE
chore: update actions/cache from v2 to v3 

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -31,7 +31,7 @@ jobs:
             image=moby/buildkit:master
 
       - name: Cache main image layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.13-alpine3.20 as build
+FROM golang:1.22-alpine AS build
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Update deprecated actions/cache@v2 to v3 to prevent workflow interruptions. Required update as v2 has beeen deprecated by GitHub Actions 

See: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/