### PR TITLE
Chore: bump eigensdk-go to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.2
 
 require (
-	github.com/Layr-Labs/eigensdk-go v0.3.0
+	github.com/Layr-Labs/eigensdk-go v1.0.0-rc.1
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Layr-Labs/eigensdk-go v0.3.0 h1:Z4xhBDBW9JV0CCTZ3kuTCj53t4nB8OOVxhKxy/sefO4=
-github.com/Layr-Labs/eigensdk-go v0.3.0/go.mod h1:PIBT6xEoHR0mSADTfdQ+pu4LySlt0sr7UML0Wa6DKrM=
+github.com/Layr-Labs/eigensdk-go v1.0.0-rc.1 h1:pH4RnJEk9NzxwzGIoUCj3cuOYx3rsb5JruGeqiyvdOw=
+github.com/Layr-Labs/eigensdk-go v1.0.0-rc.1/go.mod h1:PIBT6xEoHR0mSADTfdQ+pu4LySlt0sr7UML0Wa6DKrM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=

--- a/integration_test.go
+++ b/integration_test.go
@@ -444,22 +444,33 @@ func startAnvilTestContainer(t *testing.T, additionalFlags ...string) testcontai
 	integrationDir, err := os.Getwd()
 	require.NoError(t, err)
 
+	tmpDir, err := os.MkdirTemp("", "anvil-state")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	stateFilePath := filepath.Join(integrationDir, "tests/eigenlayer-eigencert-eigenda-strategies-deployed-operators-registered-with-eigenlayer-anvil-state.json")
+	tmpStatePath := filepath.Join(tmpDir, "state.json")
+	stateData, err := os.ReadFile(stateFilePath)
+	require.NoError(t, err)
+	err = os.WriteFile(tmpStatePath, stateData, 0666)
+	require.NoError(t, err)
+
 	cmdArgs := []string{
 		"--host", "0.0.0.0",
-		"--load-state", "/root/.anvil/state.json",
+		"--load-state", "/data/state.json",
 	}
 
 	cmdArgs = append(cmdArgs, additionalFlags...)
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image: "ghcr.io/foundry-rs/foundry:stable@sha256:daeeaaf4383ee0cbfc9f31f079a04ffb0123e49e5f67f2a20b5ce1ac1959a4d6",
+		Image: "ghcr.io/foundry-rs/foundry:stable",
 		Mounts: testcontainers.ContainerMounts{
 			testcontainers.ContainerMount{
 				Source: testcontainers.GenericBindMountSource{
-					HostPath: filepath.Join(integrationDir, "tests/eigenlayer-eigencert-eigenda-strategies-deployed-operators-registered-with-eigenlayer-anvil-state.json"),
+					HostPath: tmpStatePath,
 				},
-				Target: "/root/.anvil/state.json",
+				Target: "/data/state.json",
 			},
 		},
 		Entrypoint:   []string{"anvil"},


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
This PR addresses the following issues:
- Bumping eigensdk-go to v1.0.0 release candidate in preparation for mainnet slashing
- Container image availability issues with the pinned stable foundry SHA256 version
- Subsequent permissioning issues when the test anvil docker container tried to load the state file
### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Fixed permission issues:
- Changed mount location from /root/.anvil/state.json to /data/state.json
- Added a shell command to explicitly set file permissions with chmod 644 then
made sure this command is run before starting Anvil

Updated Foundry Docker image reference:
- Changed from a pinned SHA256 digest to the stable tag

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->